### PR TITLE
feat: make debezium topic name optional

### DIFF
--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -307,7 +307,7 @@ function deployApplication(
 
 /**
  * Deploys an application suite to a single provider.
- * An application suite consists of several deployable units (i.e api, background worker).
+ * An application suite consists of several deployable units (i.e. api, background worker).
  * A suite can also require a migration job and/or a debezium instance.
  */
 export function deployApplicationSuiteToProvider({
@@ -372,14 +372,13 @@ export function deployApplicationSuiteToProvider({
   }
 
   if (debezium) {
-    const props = getDebeziumProps(
-      debezium.propsPath,
-      {
-        ...debezium.propsVars,
-        topic: debezium.topicName,
-      },
-      isAdhocEnv,
-    );
+    const propsVars = {
+      ...debezium.propsVars,
+    };
+    if (debezium.topicName) {
+      propsVars.topic = debezium.topicName;
+    }
+    const props = getDebeziumProps(debezium.propsPath, propsVars, isAdhocEnv);
     const diskSize = 100;
     // IMPORTANT: do not set resource prefix here, otherwise it might create new disk and other resources
     const { debeziumKey, disk } = deployDebeziumSharedDependencies(

--- a/src/suite/types.ts
+++ b/src/suite/types.ts
@@ -64,7 +64,7 @@ export type CronArgs = {
 };
 
 export type DebeziumArgs = {
-  topicName: string;
+  topicName?: string;
   propsPath: string;
   propsVars: Record<string, Input<string>>;
   dependenciesOnly?: boolean;


### PR DESCRIPTION
So we can configure debezium with or without topic at all. Backward compatible.

```
debezium: {
        propsPath: './application.properties',
        propsVars: {
            topic: debeziumTopicName,
            database_pass: databasePass,
            database_user: databaseUser.name,
            database_dbname: database.name,
            hostname: cloudSqlInstance.privateIpAddress,
        },
        limits: {
            cpu: '1',
            memory: '1G',
        },
        version: '2.0',
    },
```