### PR TITLE
feat: automagically create exposed application if `servicePorts` length is > 0

### DIFF
--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -303,7 +303,7 @@ function deployApplication(
     ports,
     servicePorts,
   };
-  if (createService) {
+  if (createService || servicePorts.length > 0) {
     return createAutoscaledExposedApplication({
       ...appArgs,
       serviceType: vpcNative ? 'ClusterIP' : serviceType,


### PR DESCRIPTION
Just in case you forget to set `createService` 😬