### PR TITLE
feat: add additional label to differentiate between deployments and cron jobs with the same name

### DIFF
--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -169,6 +169,7 @@ function deployCron(
         namespace,
         labels: {
           app: appName,
+          'app-type': 'cron',
           ...labels,
         },
       },


### PR DESCRIPTION
Example in API, where there's a Deployment with the name `api-daily-digest` and a CronJon with the same name, both get the labels `app=api-daily-digest`, so in metrics or logs it's not easy to separate them.
This adds a new label to CronJobs so we can more easily query them based on that label too.