### PR TITLE
feat: create ClickhouseSync resources

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+src
+.circleci
+.github
+.editorconfig
+.eslintignore
+.eslintrc.js
+.nvmrc
+.prettier.rc
+CODEOWNERS
+tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@pulumi/pulumi": "^3.113.3",
         "knex": "^3.1.0",
         "mysql": "^2.18.1",
-        "pg": "^8.11.5"
+        "pg": "^8.11.5",
+        "yaml": "^2.4.1"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.7.0",
@@ -6194,6 +6195,17 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -10764,6 +10776,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint . --ext .js,.ts --max-warnings 0",
     "build": "tsc",
+    "dev": "tsc --watch",
     "prebuild": "rm -rf lib",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@pulumi/pulumi": "^3.113.3",
     "knex": "^3.1.0",
     "mysql": "^2.18.1",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "yaml": "^2.4.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dailydotdev/pulumi-common",
   "version": "1.32.3",
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "scripts": {
     "lint": "eslint . --ext .js,.ts --max-warnings 0",
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,5 @@ export * from './providers/gkeCluster';
 export * from './providers/pubsubEmulator';
 export * from './suite/types';
 export * from './suite/index';
-export * from './resources/redis';
-export * from './resources/stream';
-export * from './resources/sql';
+export * from './resources';
 export * from './kubernetes';

--- a/src/kubernetes/types.ts
+++ b/src/kubernetes/types.ts
@@ -1,9 +1,16 @@
 import { Input } from '@pulumi/pulumi';
 
-export type Image = {
-  repository: Input<string>;
-  tag: Input<string>;
-};
+export type Image =
+  | {
+      repository: Input<string>;
+      tag: Input<string>;
+      digest?: never;
+    }
+  | {
+      repository: Input<string>;
+      tag?: never;
+      digest: Input<string>;
+    };
 
 export type Tolerations = {
   key: Input<string>;

--- a/src/kubernetes/types.ts
+++ b/src/kubernetes/types.ts
@@ -14,11 +14,11 @@ export type Image =
 
 export type Resources = {
   requests: {
-    cpu?: Input<string>;
-    memory?: Input<string>;
+    cpu: Input<string>;
+    memory: Input<string>;
   };
   limits: {
-    memory?: Input<string>;
+    memory: Input<string>;
   };
 };
 

--- a/src/kubernetes/types.ts
+++ b/src/kubernetes/types.ts
@@ -12,6 +12,16 @@ export type Image =
       digest: Input<string>;
     };
 
+export type Resources = {
+  requests: {
+    cpu?: Input<string>;
+    memory?: Input<string>;
+  };
+  limits: {
+    memory?: Input<string>;
+  };
+};
+
 export type Tolerations = {
   key: Input<string>;
   value: Input<string>;

--- a/src/kubernetes/utils.ts
+++ b/src/kubernetes/utils.ts
@@ -1,3 +1,5 @@
+import { Image } from './types';
+
 export const NodeLabelKeys = {
   Type: 'node.daily.dev/type',
   OptimizedRedis: 'node.daily.dev/optimized-redis',
@@ -38,4 +40,13 @@ export const extractNodeLabels = (
   return {
     [label.key]: label.value,
   };
+};
+
+/**
+ * Returns the image string to be used in a Kubernetes deployment.
+ * If a digest is provided, it will be used instead of the tag.
+ */
+export const image = ({ repository, tag, digest }: Image) => {
+  const separator = digest ? '@' : ':';
+  return `${repository}${separator}${digest || tag}`;
 };

--- a/src/kubernetes/utils.ts
+++ b/src/kubernetes/utils.ts
@@ -1,3 +1,4 @@
+import { version } from '../../package.json';
 import { Image } from './types';
 
 export const NodeLabelKeys = {
@@ -41,6 +42,15 @@ export const extractNodeLabels = (
     [label.key]: label.value,
   };
 };
+
+/**
+ * Common labels used in the daily.dev infrastructure.
+ * These labels are used to identify resources created by pulumi, and of which version of the pulumi-common library was used to create them.
+ */
+export const commonLabels = {
+  'app.kubernetes.io/managed-by': 'pulumi',
+  'pulumi-common.daily.dev/version': version,
+} as const;
 
 /**
  * Returns the image string to be used in a Kubernetes deployment.

--- a/src/kubernetes/utils.ts
+++ b/src/kubernetes/utils.ts
@@ -68,17 +68,19 @@ export const configureResources = (
     resources?: Resources;
   },
 ): Output<Resources> | undefined => {
-  return args.isAdhocEnv
-    ? undefined
-    : all([args.resources]).apply(([resources]) => {
-        return {
-          requests: {
-            cpu: resources?.requests?.cpu || '1000m',
-            memory: resources?.requests?.memory || '1Gi',
-          },
-          limits: {
-            memory: resources?.limits?.memory || '2Gi',
-          },
-        };
-      });
+  if (args.isAdhocEnv || args.resources === undefined) {
+    return undefined;
+  }
+
+  return all([args.resources]).apply(([resources]) => {
+    return {
+      requests: {
+        cpu: resources.requests.cpu,
+        memory: resources.requests.memory,
+      },
+      limits: {
+        memory: resources.limits.memory,
+      },
+    };
+  });
 };

--- a/src/kubernetes/utils.ts
+++ b/src/kubernetes/utils.ts
@@ -1,5 +1,7 @@
+import { Output, all } from '@pulumi/pulumi';
 import { version } from '../../package.json';
-import { Image } from './types';
+import { Image, Resources } from './types';
+import { AdhocEnv } from '../utils';
 
 export const NodeLabelKeys = {
   Type: 'node.daily.dev/type',
@@ -59,4 +61,24 @@ export const commonLabels = {
 export const image = ({ repository, tag, digest }: Image) => {
   const separator = digest ? '@' : ':';
   return `${repository}${separator}${digest || tag}`;
+};
+
+export const configureResources = (
+  args: AdhocEnv & {
+    resources?: Resources;
+  },
+): Output<Resources> | undefined => {
+  return args.isAdhocEnv
+    ? undefined
+    : all([args.resources]).apply(([resources]) => {
+        return {
+          requests: {
+            cpu: resources?.requests?.cpu || '1000m',
+            memory: resources?.requests?.memory || '1Gi',
+          },
+          limits: {
+            memory: resources?.limits?.memory || '2Gi',
+          },
+        };
+      });
 };

--- a/src/resources/clickHouseSync/index.ts
+++ b/src/resources/clickHouseSync/index.ts
@@ -75,9 +75,6 @@ export class ClickHouseSync extends ComponentResource {
           ...commonLabels,
           'app.kubernetes.io/name': `${name}-clickhouse-sync-config`,
         },
-        annotations: {
-          'chekcsum/secret': configChecksum,
-        },
       },
       data: {
         'config.yml': config,

--- a/src/resources/clickHouseSync/index.ts
+++ b/src/resources/clickHouseSync/index.ts
@@ -1,0 +1,173 @@
+import * as k8s from '@pulumi/kubernetes';
+import {
+  ComponentResource,
+  CustomResourceOptions,
+  Input,
+} from '@pulumi/pulumi';
+
+import { urnPrefix } from '../../constants';
+import { AdhocEnv } from '../../utils';
+import {
+  Image,
+  Resources,
+  commonLabels,
+  configureResources,
+  image,
+} from '../../kubernetes';
+import { ClickHouseSyncConfig, loadConfig } from './utils';
+import { stringify } from 'yaml';
+import { createHash } from 'crypto';
+
+export type ClickHouseSyncArgs = AdhocEnv & {
+  props: {
+    path: string;
+    keys: ClickHouseSyncConfig;
+    vars?: Record<string, Input<string>>;
+  };
+  deployment?: {
+    name?: Input<string>;
+  };
+  namespace: Input<string>;
+  image?: Image;
+  resources?: Resources;
+};
+
+const defaults: {
+  image: Image;
+} = {
+  image: {
+    repository: 'altinity/clickhouse-sink-connector',
+    digest:
+      'sha256:1c0db9877331a0aaceb2e0f2838db3a5156a3cfbfdb83a92235b6287b576c5d0',
+  },
+};
+
+export class ClickHouseSync extends ComponentResource {
+  private deployment: k8s.apps.v1.Deployment;
+  private config: k8s.core.v1.Secret;
+
+  constructor(
+    name: string,
+    args: ClickHouseSyncArgs,
+    resourceOptions?: CustomResourceOptions,
+  ) {
+    super(`${urnPrefix}:ClickHouseSync`, name, args, resourceOptions);
+
+    const deploymentName = args.deployment?.name || `${name}-clickhouse-sync`;
+
+    const config = loadConfig(args.props.path, args.props.vars).apply(
+      (config) => {
+        return Buffer.from(
+          stringify({ ...config, ...args.props.keys }),
+        ).toString('base64');
+      },
+    );
+
+    const configChecksum = config.apply((configString) =>
+      createHash('sha256').update(configString).digest('hex'),
+    );
+
+    this.config = new k8s.core.v1.Secret('clickhouse-sync-config', {
+      metadata: {
+        namespace: args.namespace,
+        name: `${name}-clickhouse-sync-config`,
+        labels: {
+          ...commonLabels,
+          'app.kubernetes.io/name': `${name}-clickhouse-sync-config`,
+        },
+        annotations: {
+          'chekcsum/secret': configChecksum,
+        },
+      },
+      data: {
+        'config.yml': config,
+      },
+    });
+
+    this.deployment = new k8s.apps.v1.Deployment(
+      `${name}-clickhouse-sync`,
+      {
+        metadata: {
+          namespace: args.namespace,
+          name: deploymentName,
+          labels: {
+            ...commonLabels,
+            'app.kubernetes.io/name': deploymentName,
+          },
+          annotations: {
+            'chekcsum/secret': configChecksum,
+          },
+        },
+        spec: {
+          replicas: 1,
+          strategy: {
+            type: 'Recreate',
+          },
+          selector: {
+            matchLabels: {
+              'app.kubernetes.io/name': deploymentName,
+            },
+          },
+          template: {
+            metadata: {
+              labels: {
+                'app.kubernetes.io/name': deploymentName,
+              },
+            },
+            spec: {
+              containers: [
+                {
+                  name: 'clickhouse-sink-connector',
+                  image: image(args.image || defaults.image),
+                  // Need to change the command from upstream, as we can't mount the config file directly to root directory
+                  command: [
+                    'java',
+                    '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005',
+                    '-jar',
+                    '/app.jar',
+                    '/config/config.yml',
+                    'com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication',
+                  ],
+                  ports: [
+                    {
+                      name: 'healthcheck',
+                      containerPort: 8080,
+                    },
+                  ],
+                  env: [],
+                  resources: configureResources({
+                    isAdhocEnv: args.isAdhocEnv,
+                    resources: args.resources,
+                  }),
+                  livenessProbe: {
+                    httpGet: {
+                      path: '/q/health',
+                      port: 'healthcheck',
+                    },
+                    initialDelaySeconds: 60,
+                    periodSeconds: 30,
+                  },
+                  volumeMounts: [
+                    {
+                      name: 'clickhouse-config',
+                      mountPath: '/config',
+                    },
+                  ],
+                },
+              ],
+              volumes: [
+                {
+                  name: 'clickhouse-config',
+                  secret: {
+                    secretName: this.config.metadata.name,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      resourceOptions,
+    );
+  }
+}

--- a/src/resources/clickHouseSync/index.ts
+++ b/src/resources/clickHouseSync/index.ts
@@ -67,7 +67,7 @@ export class ClickHouseSync extends ComponentResource {
       createHash('sha256').update(configString).digest('hex'),
     );
 
-    this.config = new k8s.core.v1.Secret('clickhouse-sync-config', {
+    this.config = new k8s.core.v1.Secret(`${name}-clickhouse-sync-config`, {
       metadata: {
         namespace: args.namespace,
         name: `${name}-clickhouse-sync-config`,

--- a/src/resources/clickHouseSync/utils.ts
+++ b/src/resources/clickHouseSync/utils.ts
@@ -1,0 +1,62 @@
+import { Input, all } from '@pulumi/pulumi';
+import { readFile } from 'fs/promises';
+import { parse } from 'yaml';
+
+export type ClickHouseSyncConfig = Partial<{
+  name: string;
+  'slot.name': string;
+  'database.hostname': string;
+  'database.port': string;
+  'database.user': string;
+  'database.password': string;
+  'database.server.name': string;
+  'schema.include.list': string;
+  'plugin.name': string;
+  'table.include.list': string;
+  'clickhouse.server.url': string;
+  'clickhouse.server.user': string;
+  'clickhouse.server.password': string;
+  'clickhouse.server.port': string;
+  'clickhouse.server.database': string;
+  'database.allowPublicKeyRetrieval': string;
+  'snapshot.mode': string;
+  'offset.flush.interval.ms': number;
+  'connector.class': string;
+  'offset.storage': string;
+  'offset.storage.jdbc.offset.table.name': string;
+  'offset.storage.jdbc.url': string;
+  'offset.storage.jdbc.user': string;
+  'offset.storage.jdbc.password': string;
+  'offset.storage.jdbc.offset.table.ddl': string;
+  'offset.storage.jdbc.offset.table.delete': string;
+  'schema.history.internal': string;
+  'schema.history.internal.jdbc.url': string;
+  'schema.history.internal.jdbc.user': string;
+  'schema.history.internal.jdbc.password': string;
+  'schema.history.internal.jdbc.schema.history.table.ddl': string;
+  'schema.history.internal.jdbc.schema.history.table.name': string;
+  'enable.snapshot.ddl': string;
+  'auto.create.tables': string;
+  'database.dbname': string;
+  'clickhouse.datetime.timezone': string;
+  skip_replica_start: string;
+  'binary.handling.mode': string;
+  ignore_delete: string;
+  'disable.ddl': string;
+  'disable.drop.truncate': string;
+}>;
+
+// Load the configuration from a file, replacing any variables in the file with the provided values.
+export const loadConfig = (
+  configPath: string,
+  configVars?: Record<string, Input<string>>,
+) =>
+  all([configPath, configVars ?? {}]).apply(async ([path, vars]) =>
+    parse(
+      Object.keys(vars).reduce(
+        // Use regex to replace all instances of the variable in the file.
+        (acc, key) => acc.replace(RegExp(`%${key}%`, 'g'), vars[key]),
+        await readFile(path, 'utf-8'),
+      ),
+    ),
+  );

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,1 +1,4 @@
 export * from './redis';
+export * from './clickHouseSync';
+export * from './stream';
+export * from './sql';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true,
   },
   "files": ["src/index.ts"]
 }


### PR DESCRIPTION
feat: add dev script
Makes it easier to run npm link when creating common libs, without having to manually run npm run build each time

feat: load the package.json into package
Used for common labels to set what version of pulumi-common is used to create deployment

feat: ignore files from npm package
Reduce files in npm package