### PR TITLE
fix: allow setting different storage size

### DIFF
--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -26,6 +26,7 @@ export class KubernetesRedis extends pulumi.ComponentResource {
     const redisInstance = {
       persistence: configurePersistence({
         memorySizeGb: args.memorySizeGb,
+        storageSizeGb: args.storageSizeGb,
         persistence: args.persistence,
       }),
       resources: configureResources({

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -60,6 +60,7 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
           },
           persistence: configurePersistence({
             memorySizeGb: args.memorySizeGb,
+            storageSizeGb: args.storageSizeGb,
             persistence: args.persistence,
           }),
         },


### PR DESCRIPTION
If memory size is larger then storage size, throw an error.

Because it is a redis is deployed as a stateful set, it is not possible to re-scale the PVC. So with this change, we can set the storage size to any number larger than memory, which allows us to scale memory up and down.

If we need to scale up storage, the statefulset has to be re-created