### PR TITLE
fix: add timeout option for helm

### DIFF
--- a/src/resources/redis/common.ts
+++ b/src/resources/redis/common.ts
@@ -24,6 +24,7 @@ export type CommonK8sRedisArgs = Partial<AdhocEnv> & {
   replicas: Input<number>;
   image?: Input<Image>;
   authKey?: Input<string>;
+  timeout?: Input<number>;
 
   persistence?: Input<{
     enabled?: Input<boolean>;

--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -43,6 +43,7 @@ export class KubernetesRedis extends pulumi.ComponentResource {
         namespace: args.namespace,
         createNamespace: false,
         atomic: true,
+        timeout: args.timeout,
         values: {
           fullnameOverride: name,
           commonConfiguration: commonConfiguration,

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -30,6 +30,7 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
         namespace: args.namespace,
         createNamespace: false,
         atomic: true,
+        timeout: args.timeout,
         values: {
           fullnameOverride: name,
           commonConfiguration: commonConfiguration,


### PR DESCRIPTION
This is useful as helm waits for all pods to be ready, but with redis it takes a few minutes for it to load everything into memory