### PR TITLE
ApplicationSuiteArgs: migrations

### DIFF
--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -336,6 +336,7 @@ export function deployApplicationSuiteToProvider({
   resourcePrefix = '',
   vpcNative = false,
   migration,
+  migrations,
   debezium,
   crons,
   shouldBindIamUser,
@@ -400,6 +401,22 @@ export function deployApplicationSuiteToProvider({
       { provider, resourcePrefix, dependsOn: suiteDependsOn },
     );
     dependsOn.push(migrationJob);
+  }
+
+  // Run migrations if needed
+  if (migrations) {
+    Object.keys(migrations).map((key) => {
+      const migrationJob = createMigrationJob(
+        `${name}-${key}-migration`,
+        namespace,
+        image,
+        migrations[key].args,
+        containerEnvVars,
+        k8sServiceAccount,
+        { provider, resourcePrefix, dependsOn: suiteDependsOn },
+      );
+      dependsOn.push(migrationJob);
+    });
   }
 
   if (debezium) {

--- a/src/suite/types.ts
+++ b/src/suite/types.ts
@@ -100,6 +100,7 @@ export type ApplicationSuiteArgs = {
   resourcePrefix?: string;
   vpcNative?: boolean;
   migration?: MigrationArgs;
+  migrations?: { [key: string]: MigrationArgs };
   debezium?: DebeziumArgs;
   crons?: CronArgs[];
   shouldBindIamUser: boolean;


### PR DESCRIPTION
For the feed, this PR adds an opportunity for having multiple migrations, like
```
migrations: {
    pg: {
        args: ['./feed', 'migrate_pgdb', '--prefixes=feed', '--migration_path=/migrations'],
    },
    ch: {
        args: ['./feed', 'migrate_chdb', '--prefixes=feed', '--migration_path=/migrations_ch'],
    },
}
```
