### PR TITLE
fix: type is `AverageValue`

### DIFF
--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -59,7 +59,7 @@ export function customMetricToK8s(
               },
             },
             target: {
-              type: 'Value',
+              type: 'AverageValue',
               averageValue: metric.targetAverageValue.toString(),
             },
           },


### PR DESCRIPTION
api-bg hasn't auto scaled in ages, and looking at hpa in k8s
```
metric with type External specifies targetType Value but doesn't specify Value
```

So I think type should be `AverageValue`