### PR TITLE
feat: add option to add `customResponseHeaders` to the Ingress

### DIFF
--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -261,6 +261,7 @@ function deployApplication(
     isApi = createService,
     ports = [],
     servicePorts = [],
+    backendConfig,
   }: ApplicationArgs,
 ): ApplicationReturn {
   const appResourcePrefix = `${resourcePrefix}${
@@ -314,6 +315,7 @@ function deployApplication(
       serviceType: vpcNative ? 'ClusterIP' : serviceType,
       enableCdn,
       serviceTimeout,
+      backendConfig,
     });
   }
   return createAutoscaledApplication(appArgs);

--- a/src/suite/types.ts
+++ b/src/suite/types.ts
@@ -45,6 +45,9 @@ export type ApplicationArgs = {
   podAnnotations?: Input<{ [key: string]: Input<string> }>;
   ports?: k8s.types.input.core.v1.ContainerPort[];
   servicePorts?: k8s.types.input.core.v1.ServicePort[];
+  backendConfig?: Input<{
+    customResponseHeaders?: Input<string[]>;
+  }>;
 };
 
 export type ApplicationReturn = KubernetesApplicationReturn & {


### PR DESCRIPTION
Adds option to add custom response headers to GKE ingress. This could allow us to globally set headers like CORS for api.daily.dev e.g.

~Need to test it locally to see if pulumi code actually works 🙈~ Checked and works

https://github.com/dailydotdev/daily-api/pull/2048