### PR TITLE
fix: re-enable the disabled commands

### DIFF
--- a/src/resources/redis/common.ts
+++ b/src/resources/redis/common.ts
@@ -28,6 +28,7 @@ export type CommonK8sRedisArgs = Partial<AdhocEnv> & {
 
   modules?: Input<string[]>;
   configuration?: Input<string>;
+  disableCommands?: Input<string[]>;
 
   persistence?: Input<{
     enabled?: Input<boolean>;

--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -24,6 +24,7 @@ export class KubernetesRedis extends pulumi.ComponentResource {
     super(`${urnPrefix}:KubernetesRedis`, name, args, resourceOptions);
 
     const redisInstance = {
+      disableCommands: args.disableCommands ?? [],
       persistence: configurePersistence({
         memorySizeGb: args.memorySizeGb,
         storageSizeGb: args.storageSizeGb,


### PR DESCRIPTION
`FLUSHDB` and `FLUSHALL` is disabled by default.
This re-enables them, but also makes it possible to disable other commands via config