### PR TITLE
feat: allow custom configuration in redis

### DIFF
--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -5,7 +5,7 @@ import { urnPrefix } from '../../constants';
 import { charts } from '../../kubernetes';
 import {
   CommonK8sRedisArgs,
-  commonConfiguration,
+  configureConfiguration,
   configurePersistence,
   configureResources,
   defaultImage,
@@ -46,7 +46,10 @@ export class KubernetesRedis extends pulumi.ComponentResource {
         timeout: args.timeout,
         values: {
           fullnameOverride: name,
-          commonConfiguration: commonConfiguration,
+          commonConfiguration: configureConfiguration({
+            modules: args.modules,
+            configuration: args.configuration,
+          }),
           image: pulumi.all([args.image]).apply(([image]) => ({
             repository: image?.repository || defaultImage.repository,
             tag: image?.tag || defaultImage.tag,

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -3,7 +3,7 @@ import * as k8s from '@pulumi/kubernetes';
 import { urnPrefix } from '../../constants';
 import {
   CommonK8sRedisArgs,
-  commonConfiguration,
+  configureConfiguration,
   configurePersistence,
   configureResources,
   defaultImage,
@@ -33,7 +33,10 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
         timeout: args.timeout,
         values: {
           fullnameOverride: name,
-          commonConfiguration: commonConfiguration,
+          commonConfiguration: configureConfiguration({
+            modules: args.modules,
+            configuration: args.configuration,
+          }),
           image: pulumi.all([args.image]).apply(([image]) => ({
             repository: image?.repository || defaultImage.repository,
             tag: image?.tag || defaultImage.tag,


### PR DESCRIPTION
Adds two new arguments for Redis, `modules` which accepts an array of paths to modules, and `configuration` which takes a string of redis config.

If no `modules` are set, it defaults to `redisearch` and `rejson`