### PR TITLE
chore: minor adjustments to redis

### DIFF
--- a/src/kubernetes/charts.ts
+++ b/src/kubernetes/charts.ts
@@ -1,7 +1,7 @@
 export const charts = {
   redis: {
     chart: 'redis',
-    version: '20.0.3',
+    version: '20.2.1',
     repositoryOpts: {
       repo: 'https://charts.bitnami.com/bitnami',
     },

--- a/src/kubernetes/charts.ts
+++ b/src/kubernetes/charts.ts
@@ -8,7 +8,7 @@ export const charts = {
   },
   'redis-cluster': {
     chart: 'redis-cluster',
-    version: '11.0.3',
+    version: '11.0.6',
     repositoryOpts: {
       repo: 'https://charts.bitnami.com/bitnami',
     },

--- a/src/kubernetes/priorityClass.ts
+++ b/src/kubernetes/priorityClass.ts
@@ -1,6 +1,6 @@
 import { CustomResource } from '@pulumi/kubernetes/apiextensions';
 import type { PriorityClassArgs } from '@pulumi/kubernetes/scheduling/v1alpha1';
-import type { CustomResourceOptions } from '@pulumi/pulumi';
+import type { CustomResourceOptions, Input } from '@pulumi/pulumi';
 
 export const PreemptionPolicies = {
   PreemptLowerPriority: 'PreemptLowerPriority',
@@ -38,6 +38,34 @@ export const PriorityClasses = {
     description: 'Used for stateful Redis pods.',
   },
 } as const;
+
+export type PriorityClass =
+  (typeof PriorityClasses)[keyof typeof PriorityClasses];
+
+export type PriorityClassInput =
+  | {
+      /**
+       * The priority class to use for the Redis pods.
+       * If not provided, the default priority class will be used.
+       * If provided, the priority class must be defined in the `PriorityClasses` object.
+       *
+       * This option is mutually exclusive with `priorityClass`.
+       * If both are provided, `priorityClassName` will be used.
+       */
+      priorityClass: Input<PriorityClass>;
+      priorityClassName: never;
+    }
+  | {
+      priorityClass: never;
+      /**
+       * The name of the priority class to use for the Redis pods.
+       * If not provided, the default priority class will be used.
+       *
+       * This option is mutually exclusive with `priorityClass`.
+       * If both are provided, `priorityClassName` will be used.
+       */
+      priorityClassName: Input<string>;
+    };
 
 export const createPriorityClass = (
   {

--- a/src/resources/redis/common.ts
+++ b/src/resources/redis/common.ts
@@ -25,6 +25,7 @@ export type CommonK8sRedisArgs = Partial<AdhocEnv> & {
   image?: Input<Image>;
   authKey?: Input<string>;
   timeout?: Input<number>;
+  safeToEvict?: Input<boolean>;
 
   modules?: Input<string[]>;
   configuration?: Input<string>;

--- a/src/resources/redis/common.ts
+++ b/src/resources/redis/common.ts
@@ -4,7 +4,7 @@ import {
   Affinity,
   Image,
   Tolerations,
-  PriorityClasses,
+  type PriorityClassInput,
 } from '../../kubernetes';
 import { AdhocEnv } from '../../utils';
 
@@ -21,7 +21,7 @@ export const defaultImage = {
   tag: '7.2.0-v10',
 };
 
-export type CommonK8sRedisArgs = Partial<AdhocEnv> & {
+export type CommonK8sRedisArgs = Partial<AdhocEnv & PriorityClassInput> & {
   memorySizeGb: Input<number>;
   storageSizeGb?: Input<number>;
   cpuSize?: Input<number | string>;
@@ -30,7 +30,6 @@ export type CommonK8sRedisArgs = Partial<AdhocEnv> & {
   image?: Input<Image>;
   authKey?: Input<string>;
   timeout?: Input<number>;
-  priorityClass?: Input<typeof PriorityClasses>;
   safeToEvict?: Input<boolean>;
 
   modules?: Input<string[]>;
@@ -123,4 +122,19 @@ export const configureResources = (
           };
     },
   );
+};
+
+export const configurePriorityClass = (
+  args: CommonK8sRedisArgs,
+): Output<string | undefined> => {
+  return all([
+    args.isAdhocEnv,
+    args.priorityClass,
+    args.priorityClassName,
+  ]).apply(([isAdhocEnv, priorityClass, priorityClassName]) => {
+    if (isAdhocEnv) {
+      return undefined;
+    }
+    return priorityClass ? priorityClass.name : priorityClassName;
+  });
 };

--- a/src/resources/redis/common.ts
+++ b/src/resources/redis/common.ts
@@ -1,6 +1,11 @@
 import { all, Input, Output } from '@pulumi/pulumi';
 
-import { Affinity, Image, Tolerations } from '../../kubernetes';
+import {
+  Affinity,
+  Image,
+  Tolerations,
+  PriorityClasses,
+} from '../../kubernetes';
 import { AdhocEnv } from '../../utils';
 
 /**
@@ -25,6 +30,7 @@ export type CommonK8sRedisArgs = Partial<AdhocEnv> & {
   image?: Input<Image>;
   authKey?: Input<string>;
   timeout?: Input<number>;
+  priorityClass?: Input<typeof PriorityClasses>;
   safeToEvict?: Input<boolean>;
 
   modules?: Input<string[]>;

--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -7,6 +7,7 @@ import {
   CommonK8sRedisArgs,
   configureConfiguration,
   configurePersistence,
+  configurePriorityClass,
   configureResources,
   defaultImage,
 } from './common';
@@ -37,7 +38,7 @@ export class KubernetesRedis extends pulumi.ComponentResource {
         memorySizeGb: args.memorySizeGb,
         cpuSize: args.cpuSize,
       }),
-      priorityClassName: args.priorityClass,
+      priorityClassName: configurePriorityClass(args),
     };
 
     new k8s.helm.v3.Release(

--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -37,6 +37,7 @@ export class KubernetesRedis extends pulumi.ComponentResource {
         memorySizeGb: args.memorySizeGb,
         cpuSize: args.cpuSize,
       }),
+      priorityClassName: args.priorityClass,
     };
 
     new k8s.helm.v3.Release(

--- a/src/resources/redis/kubernetesRedis.ts
+++ b/src/resources/redis/kubernetesRedis.ts
@@ -53,6 +53,10 @@ export class KubernetesRedis extends pulumi.ComponentResource {
             modules: args.modules,
             configuration: args.configuration,
           }),
+          commonAnnotations: {
+            'cluster-autoscaler.kubernetes.io/safe-to-evict':
+              args?.safeToEvict ?? false,
+          },
           image: pulumi.all([args.image]).apply(([image]) => ({
             repository: image?.repository || defaultImage.repository,
             tag: image?.tag || defaultImage.tag,

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -37,6 +37,10 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
             modules: args.modules,
             configuration: args.configuration,
           }),
+          commonAnnotations: {
+            'cluster-autoscaler.kubernetes.io/safe-to-evict':
+              args?.safeToEvict ?? false,
+          },
           image: pulumi.all([args.image]).apply(([image]) => ({
             repository: image?.repository || defaultImage.repository,
             tag: image?.tag || defaultImage.tag,

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -65,6 +65,7 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
             }),
             affinity: args.affinity,
             tolerations: args.tolerations,
+            priorityClassName: args.priorityClass,
           },
           persistence: configurePersistence({
             memorySizeGb: args.memorySizeGb,

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -5,6 +5,7 @@ import {
   CommonK8sRedisArgs,
   configureConfiguration,
   configurePersistence,
+  configurePriorityClass,
   configureResources,
   defaultImage,
 } from './common';
@@ -65,7 +66,7 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
             }),
             affinity: args.affinity,
             tolerations: args.tolerations,
-            priorityClassName: args.priorityClass,
+            priorityClassName: configurePriorityClass(args),
           },
           persistence: configurePersistence({
             memorySizeGb: args.memorySizeGb,


### PR DESCRIPTION
- Upgrades charts (no breaking changes or image updates)
- Adds possibility to set `PriorityClass` on redis clusters to ensure it doesn't accidentally get evicted
- Set the `safe-to-evict` annotation to false, so that the cluster autoscaler doesn't delete nodes where redis is scheduled on.