### PR TITLE
fix: don't set empty object on affinity if spot is not enabled for app

### DIFF
--- a/src/k8s.ts
+++ b/src/k8s.ts
@@ -342,7 +342,7 @@ export const createAutoscaledApplication = ({
             containers,
             serviceAccountName: serviceAccount?.metadata.name,
             tolerations,
-            affinity,
+            affinity: spot?.enabled ? affinity : undefined,
             ...podSpec,
           },
         },

--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -266,7 +266,7 @@ function deployCron(
                   },
                 ],
                 tolerations,
-                affinity,
+                affinity: spot?.enabled ? affinity : undefined,
               },
             },
           },


### PR DESCRIPTION
This is to prevent unnecessary deployment changes just because it was given an empty object