### PR TITLE
feat: use spot by default when possible

### DIFF
--- a/src/debezium.ts
+++ b/src/debezium.ts
@@ -6,7 +6,7 @@ import { Input, Output, ProviderResource, interpolate } from '@pulumi/pulumi';
 import * as pulumi from '@pulumi/pulumi';
 import { input as inputs } from '@pulumi/kubernetes/types';
 import { stripCpuFromLimits } from './utils';
-import { PodResources } from './k8s';
+import { getSpotSettings, PodResources } from './k8s';
 
 type OptionalArgs = {
   diskType?: Input<string>;
@@ -243,6 +243,8 @@ export function deployDebeziumKubernetesResources(
     };
   }
 
+  const { tolerations } = getSpotSettings({ enabled: true }, isAdhocEnv);
+
   new k8s.apps.v1.Deployment(
     `${resourcePrefix}debezium-deployment`,
     {
@@ -267,6 +269,7 @@ export function deployDebeziumKubernetesResources(
             volumes,
             initContainers,
             affinity: !isAdhocEnv ? affinity : undefined,
+            tolerations,
             containers: [
               {
                 name: 'debezium',

--- a/src/resources/clickHouseSync/index.ts
+++ b/src/resources/clickHouseSync/index.ts
@@ -18,6 +18,7 @@ import {
 import { ClickHouseSyncConfig, loadConfig } from './utils';
 import { stringify } from 'yaml';
 import { createHash } from 'crypto';
+import { getSpotSettings } from '../../k8s';
 
 export type ClickHouseSyncArgs = Partial<AdhocEnv> & {
   props: {
@@ -72,17 +73,10 @@ export class ClickHouseSync extends ComponentResource {
       createHash('sha256').update(configString).digest('hex'),
     );
 
-    const tolerations: k8s.types.input.core.v1.Toleration[] | undefined =
-      args.toleratesSpot
-        ? [
-            {
-              key: 'spot',
-              operator: 'Equal',
-              value: 'true',
-              effect: 'NoSchedule',
-            },
-          ]
-        : undefined;
+    const { tolerations } = getSpotSettings(
+      { enabled: args?.toleratesSpot ?? true },
+      false,
+    );
 
     this.config = new k8s.core.v1.Secret(
       `${name}-clickhouse-sync-config`,

--- a/src/suite/types.ts
+++ b/src/suite/types.ts
@@ -5,6 +5,7 @@ import {
   ContainerOptions,
   KubernetesApplicationReturn,
   PodResources,
+  Spot,
 } from '../k8s';
 import * as gcp from '@pulumi/gcp';
 
@@ -52,11 +53,7 @@ export type ApplicationArgs = {
   backendConfig?: Input<{
     customResponseHeaders?: Input<string[]>;
   }>;
-  spot?: {
-    enabled: boolean;
-    weight?: number;
-    required?: boolean;
-  };
+  spot?: Spot;
 };
 
 export type ApplicationReturn = KubernetesApplicationReturn & {
@@ -82,11 +79,7 @@ export type CronArgs = {
   args?: Input<Input<string>[]>;
   volumes?: Input<Input<k8s.types.input.core.v1.Volume>[]>;
   volumeMounts?: Input<Input<k8s.types.input.core.v1.VolumeMount>[]>;
-  spot?: {
-    enabled: boolean;
-    weight?: number;
-    required?: boolean;
-  };
+  spot?: Spot;
 };
 
 export type DebeziumArgs = {


### PR DESCRIPTION
Set spot by default for the following cases:
* Applications without service (background processing)
* Debezium and CH sync