### PR TITLE
refactor: remove disk from debezium

### DIFF
--- a/src/debezium.ts
+++ b/src/debezium.ts
@@ -2,7 +2,7 @@ import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import { createHash } from 'crypto';
 import { createServiceAccountAndGrantRoles } from './serviceAccount';
-import { Input, Output, ProviderResource, interpolate } from '@pulumi/pulumi';
+import { Input, Output, ProviderResource } from '@pulumi/pulumi';
 import * as pulumi from '@pulumi/pulumi';
 import { input as inputs } from '@pulumi/kubernetes/types';
 import { stripCpuFromLimits } from './utils';
@@ -13,8 +13,6 @@ import {
 } from './k8s';
 
 type OptionalArgs = {
-  diskType?: Input<string>;
-  diskSize?: Input<number>;
   limits?: Input<PodResources>;
   env?: pulumi.Input<inputs.core.v1.EnvVar>[];
   image?: string;
@@ -25,31 +23,22 @@ type OptionalArgs = {
   affinity?: pulumi.Input<k8s.types.input.core.v1.Affinity>;
 };
 
-const DEFAULT_DISK_SIZE = 10;
-
 /**
  * Deploys only the shared dependencies for Debezium.
- * This includes disk and service account.
+ * This is the service account.
  */
 export function deployDebeziumSharedDependencies(
   name: string,
-  diskZone: Input<string>,
   {
-    diskType = 'pd-ssd',
-    diskSize = DEFAULT_DISK_SIZE,
     resourcePrefix = '',
     isAdhocEnv,
-  }: Pick<
-    OptionalArgs,
-    'resourcePrefix' | 'diskSize' | 'diskType' | 'isAdhocEnv'
-  > = {},
+  }: Pick<OptionalArgs, 'resourcePrefix' | 'isAdhocEnv'> = {},
 ): {
   debeziumSa: gcp.serviceaccount.Account | undefined;
   debeziumKey: gcp.serviceaccount.Key | undefined;
-  disk: gcp.compute.Disk | undefined;
 } {
   if (isAdhocEnv) {
-    return { debeziumKey: undefined, debeziumSa: undefined, disk: undefined };
+    return { debeziumKey: undefined, debeziumSa: undefined };
   }
 
   const { serviceAccount: debeziumSa } = createServiceAccountAndGrantRoles(
@@ -70,14 +59,7 @@ export function deployDebeziumSharedDependencies(
     },
   );
 
-  const disk = new gcp.compute.Disk(`${resourcePrefix}debezium-disk`, {
-    name: `${name}-debezium-pv`,
-    size: diskSize,
-    zone: diskZone,
-    type: diskType,
-  });
-
-  return { debeziumSa, debeziumKey, disk };
+  return { debeziumSa, debeziumKey };
 }
 
 export const deployDebeziumSharedDependenciesV2 = (
@@ -151,7 +133,6 @@ export function deployDebeziumKubernetesResources(
   namespace: string | Input<string>,
   debeziumPropsString: Output<string>,
   debeziumKey: gcp.serviceaccount.Key | undefined,
-  disk: gcp.compute.Disk | undefined,
   {
     limits: requests = {
       cpu: '1',
@@ -211,12 +192,21 @@ export function deployDebeziumKubernetesResources(
         secretName: debeziumProps.metadata.name,
       },
     },
+    {
+      name: 'data',
+      csi: {
+        driver: 'gcsfuse.csi.storage.gke.io',
+        volumeAttributes: {
+          bucketName: `${name}-debezium-storage`,
+          mountOptions: 'implicit-dirs,uid=185,gid=0',
+        },
+      },
+    },
   ];
   const volumeMounts: k8s.types.input.core.v1.VolumeMount[] = [
     { name: 'props', mountPath: '/debezium/conf' },
+    { name: 'data', mountPath: '/debezium/data' },
   ];
-
-  const initContainers: k8s.types.input.core.v1.Container[] = [];
 
   // If service account is provided
   if (debeziumKey) {
@@ -244,85 +234,6 @@ export function deployDebeziumKubernetesResources(
       mountPath: '/var/secrets/google',
     });
   }
-
-  // If external disk is provided
-  if (disk) {
-    new k8s.core.v1.PersistentVolume(
-      `${resourcePrefix}debezium-pv`,
-      {
-        metadata: {
-          name: `${name}-debezium-pv`,
-          namespace,
-        },
-        spec: {
-          accessModes: ['ReadWriteOnce'],
-          capacity: { storage: interpolate`${disk.size}Gi` },
-          claimRef: {
-            name: `${name}-debezium-pvc`,
-            namespace,
-          },
-          gcePersistentDisk: {
-            pdName: disk.name,
-            fsType: 'ext4',
-          },
-        },
-      },
-      { provider, ignoreChanges: ['spec.claimRef'] },
-    );
-
-    new k8s.core.v1.PersistentVolumeClaim(
-      `${resourcePrefix}debezium-pvc`,
-      {
-        metadata: {
-          name: `${name}-debezium-pvc`,
-          namespace,
-        },
-        spec: {
-          accessModes: ['ReadWriteOnce'],
-          resources: { requests: { storage: interpolate`${disk.size}Gi` } },
-          volumeName: `${name}-debezium-pv`,
-        },
-      },
-      { provider },
-    );
-
-    volumes.push({
-      name: 'storage',
-      persistentVolumeClaim: {
-        // Must not depend on the PVC variable because it causes deadlock
-        claimName: `${name}-debezium-pvc`,
-      },
-    });
-    volumeMounts.push({ name: 'storage', mountPath: '/pvc/data' });
-    initContainers.push({
-      name: 'copy-offsets',
-      image: 'alpine:3',
-      command: [
-        'sh',
-        '-c',
-        '[ -f /pvc/data/offsets.dat ] && mv /pvc/data/offsets.dat /debezium/data/offsets.dat || true',
-      ],
-      volumeMounts: [
-        { name: 'storage', mountPath: '/pvc/data' },
-        { name: 'gcs-fuse-csi-ephemeral', mountPath: '/debezium/data' },
-      ],
-    });
-  }
-
-  volumes.push({
-    name: 'gcs-fuse-csi-ephemeral',
-    csi: {
-      driver: 'gcsfuse.csi.storage.gke.io',
-      volumeAttributes: {
-        bucketName: `${name}-debezium-storage`,
-        mountOptions: 'implicit-dirs,uid=185,gid=0',
-      },
-    },
-  });
-  volumeMounts.push({
-    name: 'gcs-fuse-csi-ephemeral',
-    mountPath: '/debezium/data',
-  });
 
   let livenessProbe: k8s.types.input.core.v1.Probe | undefined;
   if (!disableHealthCheck) {
@@ -359,11 +270,7 @@ export function deployDebeziumKubernetesResources(
             },
           },
           spec: {
-            nodeSelector: disk
-              ? { 'topology.kubernetes.io/zone': disk.zone }
-              : undefined,
             volumes,
-            initContainers,
             affinity: !isAdhocEnv ? affinity : undefined,
             tolerations,
             serviceAccountName: k8sServiceAccount?.metadata.apply(

--- a/src/debezium.ts
+++ b/src/debezium.ts
@@ -80,7 +80,7 @@ export function deployDebeziumSharedDependencies(
   );
 
   const { bucket } = createGcsBucket({
-    name,
+    name: `${name}-debezium`,
     serviceAccount,
     resourcePrefix,
   });

--- a/src/kubernetes/storage/bucket.ts
+++ b/src/kubernetes/storage/bucket.ts
@@ -24,8 +24,8 @@ export const createGcsBucket = ({
     return {};
   }
 
-  const bucket = new Bucket(`${resourcePrefix}${name}-debezium-storage`, {
-    name: `${name}-debezium-storage`,
+  const bucket = new Bucket(`${resourcePrefix}${name}-storage`, {
+    name: `${name}-storage`,
     location: 'us',
     publicAccessPrevention: 'enforced',
     uniformBucketLevelAccess: true,
@@ -50,7 +50,7 @@ export const createGcsBucket = ({
     });
 
     bucketIAMPolicy = new BucketIAMPolicy(
-      `${resourcePrefix}${name}-debezium-storage-policy`,
+      `${resourcePrefix}${name}-storage-policy`,
       {
         bucket: bucket.name,
         policyData: objectUsers.then((objectUser) => objectUser.policyData),

--- a/src/kubernetes/storage/bucket.ts
+++ b/src/kubernetes/storage/bucket.ts
@@ -1,0 +1,65 @@
+import { getIAMPolicy } from '@pulumi/gcp/organizations/getIAMPolicy';
+import { Bucket, BucketIAMPolicy } from '@pulumi/gcp/storage';
+import type { ServiceAccount } from '@pulumi/kubernetes/core/v1';
+
+import { k8sServiceAccountToWorkloadPrincipal } from '../../k8s';
+import type { AdhocEnv } from '../../utils';
+
+export const createGcsBucket = ({
+  name,
+  serviceAccount,
+  resourcePrefix,
+  readOnly = false,
+  isAdhocEnv,
+}: {
+  name: string;
+  serviceAccount?: ServiceAccount;
+  resourcePrefix?: string;
+  readOnly?: boolean;
+} & Partial<AdhocEnv>): Partial<{
+  bucket: Bucket;
+  bucketIAMPolicy: BucketIAMPolicy;
+}> => {
+  if (isAdhocEnv) {
+    return {};
+  }
+
+  const bucket = new Bucket(`${resourcePrefix}${name}-debezium-storage`, {
+    name: `${name}-debezium-storage`,
+    location: 'us',
+    publicAccessPrevention: 'enforced',
+    uniformBucketLevelAccess: true,
+  });
+
+  let bucketIAMPolicy: BucketIAMPolicy | undefined = undefined;
+
+  if (serviceAccount) {
+    const objectUsers = getIAMPolicy({
+      bindings: [
+        {
+          role: readOnly
+            ? 'roles/storage.objectViewer'
+            : 'roles/storage.objectUser',
+          members: [
+            k8sServiceAccountToWorkloadPrincipal(
+              serviceAccount,
+            ) as unknown as string,
+          ],
+        },
+      ],
+    });
+
+    bucketIAMPolicy = new BucketIAMPolicy(
+      `${resourcePrefix}${name}-debezium-storage-policy`,
+      {
+        bucket: bucket.name,
+        policyData: objectUsers.then((objectUser) => objectUser.policyData),
+      },
+    );
+  }
+
+  return {
+    bucket,
+    bucketIAMPolicy,
+  };
+};

--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -32,7 +32,6 @@ import {
   deployDebeziumSharedDependencies,
   deployDebeziumSharedDependenciesV2,
 } from '../debezium';
-import { location } from '../config';
 import { stripCpuFromLimits } from '../utils';
 import { defaultSpotWeight } from '../constants';
 
@@ -448,17 +447,10 @@ export function deployApplicationSuiteToProvider({
       propsVars.topic = debezium.topicName;
     }
     const props = getDebeziumProps(debezium.propsPath, propsVars, isAdhocEnv);
-    const diskSize = 100;
-    // IMPORTANT: do not set resource prefix here, otherwise it might create new disk and other resources
-    const { debeziumKey, disk } = deployDebeziumSharedDependencies(
-      name,
-      `${location}-f`,
-      {
-        diskType: 'pd-ssd',
-        diskSize,
-        isAdhocEnv,
-      },
-    );
+    // IMPORTANT: do not set resource prefix here, otherwise it might create new resources
+    const { debeziumKey } = deployDebeziumSharedDependencies(name, {
+      isAdhocEnv,
+    });
     const k8sServiceAccount = deployDebeziumSharedDependenciesV2(
       {
         name,
@@ -471,24 +463,17 @@ export function deployApplicationSuiteToProvider({
     // Useful if we want to migrate Debezium without affecting its dependencies
     if (!debezium.dependenciesOnly) {
       const debeziumDefault = isAdhocEnv ? '2.0' : '1.6';
-      deployDebeziumKubernetesResources(
-        name,
-        namespace,
-        props,
-        debeziumKey,
-        disk,
-        {
-          image: `debezium/server:${debezium.version ?? debeziumDefault}`,
-          provider,
-          resourcePrefix,
-          limits: debezium.limits,
-          isAdhocEnv,
-          env: debezium.env,
-          disableHealthCheck: debezium.disableHealthCheck,
-          affinity: debezium.affinity,
-          k8sServiceAccount,
-        },
-      );
+      deployDebeziumKubernetesResources(name, namespace, props, debeziumKey, {
+        image: `debezium/server:${debezium.version ?? debeziumDefault}`,
+        provider,
+        resourcePrefix,
+        limits: debezium.limits,
+        isAdhocEnv,
+        env: debezium.env,
+        disableHealthCheck: debezium.disableHealthCheck,
+        affinity: debezium.affinity,
+        k8sServiceAccount,
+      });
     }
   }
 

--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -30,7 +30,6 @@ import {
 import {
   deployDebeziumKubernetesResources,
   deployDebeziumSharedDependencies,
-  deployDebeziumSharedDependenciesV2,
 } from '../debezium';
 import { stripCpuFromLimits } from '../utils';
 import { defaultSpotWeight } from '../constants';
@@ -448,18 +447,15 @@ export function deployApplicationSuiteToProvider({
     }
     const props = getDebeziumProps(debezium.propsPath, propsVars, isAdhocEnv);
     // IMPORTANT: do not set resource prefix here, otherwise it might create new resources
-    const { debeziumKey } = deployDebeziumSharedDependencies(name, {
-      isAdhocEnv,
-    });
-    const k8sServiceAccount = deployDebeziumSharedDependenciesV2(
-      {
-        name,
-        namespace,
-        resourcePrefix,
-        isAdhocEnv,
-      },
-      provider,
-    );
+    const { debeziumKey, serviceAccount: k8sServiceAccount } =
+      deployDebeziumSharedDependencies(
+        {
+          name,
+          namespace,
+          isAdhocEnv,
+        },
+        provider,
+      );
     // Useful if we want to migrate Debezium without affecting its dependencies
     if (!debezium.dependenciesOnly) {
       const debeziumDefault = isAdhocEnv ? '2.0' : '1.6';


### PR DESCRIPTION
Part two of debezium migration
- Unmounts PVC from debezium
- Deletes PVC and disk
- Removes nodeSelector from deployment so it can deploy on spot nodes
- Merges `deployDebeziumSharedDependencies` and `deployDebeziumSharedDependenciesV2`

This has already been tested and deployed in Heimdall Debezium