### PR TITLE
refactor: default service type to `ClusterIP`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/pubsub": "^4.9.0",
         "@pulumi/gcp": "^8.13.1",
-        "@pulumi/kubernetes": "^4.19.0",
+        "@pulumi/kubernetes": "^4.20.0",
         "@pulumi/pulumi": "^3.145.0",
         "knex": "^3.1.0",
         "mysql": "^2.18.1",
@@ -19,11 +19,11 @@
         "yaml": "^2.7.0"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.19.1",
-        "@typescript-eslint/parser": "^8.19.1",
+        "@typescript-eslint/eslint-plugin": "^8.20.0",
+        "@typescript-eslint/parser": "^8.20.0",
         "eslint": "^8.57.1",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-prettier": "^5.2.1",
+        "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-prettier": "^5.2.2",
         "prettier": "^3.4.2",
         "typescript": "^5.7.3"
       }
@@ -902,13 +902,13 @@
       }
     },
     "node_modules/@pulumi/kubernetes": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-4.19.0.tgz",
-      "integrity": "sha512-q11ORIJPNakGwHllEq+owBWsGuVinwUIfLR8QUeqkeUJkz8sTfkU3psqVIOIai/7XITQyKbXNRhbQAJckfudOw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-4.20.0.tgz",
+      "integrity": "sha512-+adjY0za4ND21adeqDFy5xX5o+Hin0XTJBhtCw/I5FREGBa3h/k0uIzt5AHi1gHcF6KuyG3Ecp/wBP+47RPZoA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@pulumi/pulumi": "^3.136.0",
+        "@pulumi/pulumi": "^3.142.0",
         "glob": "^10.3.10",
         "shell-quote": "^1.6.1"
       }
@@ -1283,16 +1283,17 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.1.tgz",
-      "integrity": "sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.20.0.tgz",
+      "integrity": "sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/type-utils": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/type-utils": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1312,15 +1313,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.1.tgz",
-      "integrity": "sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
+      "integrity": "sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1336,13 +1338,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
-      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.20.0.tgz",
+      "integrity": "sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1"
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1353,13 +1356,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.1.tgz",
-      "integrity": "sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.20.0.tgz",
+      "integrity": "sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.0"
       },
@@ -1376,10 +1380,11 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
-      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1389,13 +1394,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
-      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
+      "integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1415,15 +1421,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
-      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.20.0.tgz",
+      "integrity": "sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1"
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.20.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1438,12 +1445,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
-      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
+      "integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/types": "8.20.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1459,6 +1467,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2160,22 +2169,24 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz",
+      "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "eslint-config-prettier": "bin/cli.js"
+        "eslint-config-prettier": "build/bin/cli.js"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
-      "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.2.tgz",
+      "integrity": "sha512-1yI3/hf35wmlq66C8yOyrujQnel+v5l1Vop5Cl2I6ylyNTT1JbuUUnV3/41PzwTzcyDp/oF0jWE3HXvcH5AQOQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
         "synckit": "^0.9.1"
@@ -2401,9 +2412,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2411,7 +2422,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@google-cloud/pubsub": "^4.9.0",
     "@pulumi/gcp": "^8.13.1",
-    "@pulumi/kubernetes": "^4.19.0",
+    "@pulumi/kubernetes": "^4.20.0",
     "@pulumi/pulumi": "^3.145.0",
     "knex": "^3.1.0",
     "mysql": "^2.18.1",
@@ -29,11 +29,11 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.19.1",
-    "@typescript-eslint/parser": "^8.19.1",
+    "@typescript-eslint/eslint-plugin": "^8.20.0",
+    "@typescript-eslint/parser": "^8.20.0",
     "eslint": "^8.57.1",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.2.2",
     "prettier": "^3.4.2",
     "typescript": "^5.7.3"
   }

--- a/src/k8s.ts
+++ b/src/k8s.ts
@@ -445,7 +445,7 @@ export const createAutoscaledExposedApplication = ({
   serviceTimeout,
   shouldCreatePDB = true,
   provider,
-  serviceType = 'NodePort',
+  serviceType = 'ClusterIP',
   strategy = {
     type: 'RollingUpdate',
     rollingUpdate: {

--- a/src/suite/index.ts
+++ b/src/suite/index.ts
@@ -252,7 +252,6 @@ function deployApplication(
     imageTag,
     containerOpts,
     provider,
-    vpcNative,
     isAdhocEnv,
   }: ApplicationContext,
   {
@@ -336,7 +335,7 @@ function deployApplication(
   if (shouldCreateService) {
     return createAutoscaledExposedApplication({
       ...appArgs,
-      serviceType: vpcNative ? 'ClusterIP' : serviceType,
+      serviceType,
       enableCdn,
       serviceTimeout,
       backendConfig,
@@ -361,7 +360,6 @@ export function deployApplicationSuiteToProvider({
   apps,
   provider,
   resourcePrefix = '',
-  vpcNative = false,
   migration,
   migrations,
   debezium,
@@ -482,7 +480,6 @@ export function deployApplicationSuiteToProvider({
     imageTag,
     image,
     provider,
-    vpcNative,
     isAdhocEnv,
   };
   // Deploy the applications
@@ -514,7 +511,7 @@ export function deployApplicationSuiteToProvider({
 export function deployApplicationSuite(
   suite: Omit<
     ApplicationSuiteArgs,
-    'provider' | 'resourcePrefix' | 'vpcNative' | 'shouldBindIamUser'
+    'provider' | 'resourcePrefix' | 'shouldBindIamUser'
   >,
   vpcNativeProvider?: GkeCluster,
 ): ApplicationReturn[][] {
@@ -531,7 +528,6 @@ export function deployApplicationSuite(
       shouldBindIamUser: true,
       provider: (vpcNativeProvider || getVpcNativeCluster()).provider,
       resourcePrefix: 'vpc-native-',
-      vpcNative: true,
     });
     return [vpcNativeApps];
   }

--- a/src/suite/types.ts
+++ b/src/suite/types.ts
@@ -109,7 +109,6 @@ export type ApplicationSuiteArgs = {
   apps: ApplicationArgs[];
   provider?: ProviderResource;
   resourcePrefix?: string;
-  vpcNative?: boolean;
   migration?: MigrationArgs;
   migrations?: { [key: string]: MigrationArgs };
   debezium?: DebeziumArgs;
@@ -128,6 +127,5 @@ export type ApplicationContext = {
   imageTag: string;
   containerOpts: ContainerOptions;
   provider?: ProviderResource;
-  vpcNative: boolean;
   isAdhocEnv?: boolean;
 };


### PR DESCRIPTION
Change default service type to be `ClusterIP` which was the default for production cluster. And in local cluster, we expose applications via ingress, or should use `LoadBalancer` to get a more permanent port.