### PR TITLE
feat: add startupProbe override to KubernetesSentinel

### DIFF
--- a/src/resources/redis/kubernetesSentinel.ts
+++ b/src/resources/redis/kubernetesSentinel.ts
@@ -24,6 +24,14 @@ import {
 
 export type K8sRedisSentinelArgs = CommonK8sRedisArgs & {
   spot?: Spot;
+  startupProbe?: Input<{
+    enabled?: Input<boolean>;
+    initialDelaySeconds?: Input<number>;
+    periodSeconds?: Input<number>;
+    timeoutSeconds?: Input<number>;
+    failureThreshold?: Input<number>;
+    successThreshold?: Input<number>;
+  }>;
   monitor?: {
     enabled?: boolean;
     image?: K8sRedisSentinelMonitorArgs['image'];
@@ -122,8 +130,8 @@ export class KubernetesSentinel extends ComponentResource {
             enabled: !!args.authKey,
             password: args.authKey,
           },
-          replica: all([args.spot, args.isAdhocEnv]).apply(
-            ([spot, isAdhocEnv]) => {
+          replica: all([args.spot, args.isAdhocEnv, args.startupProbe]).apply(
+            ([spot, isAdhocEnv, startupProbe]) => {
               const { tolerations, affinity } = getSpotSettings(
                 spot,
                 isAdhocEnv,
@@ -131,8 +139,9 @@ export class KubernetesSentinel extends ComponentResource {
               return {
                 ...redisInstance,
                 replicaCount: args?.replicas,
-                tolerations: tolerations,
-                affinity: affinity,
+                tolerations,
+                affinity,
+                ...(startupProbe && { startupProbe }),
                 topologySpreadConstraints: [
                   {
                     maxSkew: 1,


### PR DESCRIPTION
## Summary
- Add optional `startupProbe` field to `K8sRedisSentinelArgs` so callers can override the Bitnami Redis chart's default startup probe on replicas
- Spread the probe config into the Helm `replica` values when provided
- Fixes crash-looping on large-memory Redis instances (e.g. sauron-embeddings) where RDB load exceeds the default 230s startup window

## Test plan
- [x] `npm run build` passes
- [ ] Consume from daily-feed infra and run `pulumi preview` to verify the StatefulSet diff shows updated startupProbe