### PR TITLE
feat(redis): support terminationGracePeriodSeconds for cluster and sentinel

### DIFF
--- a/src/resources/redis/common.ts
+++ b/src/resources/redis/common.ts
@@ -1,4 +1,9 @@
-import { all, type Input, type Output } from '@pulumi/pulumi';
+import {
+  all,
+  type Input,
+  type Output,
+  type ResourceTransform,
+} from '@pulumi/pulumi';
 
 import {
   type Affinity,
@@ -33,6 +38,16 @@ export type CommonK8sRedisArgs = Partial<AdhocEnv & PriorityClassInput> & {
   authKey?: Input<string>;
   timeout?: Input<number>;
   safeToEvict?: Input<boolean>;
+  /**
+   * Termination grace period (in seconds) for the Redis pods. On SIGTERM Redis
+   * flushes its AOF/RDB before exiting; if the grace period is too short the
+   * kubelet sends SIGKILL mid-write, which truncates the append-only file and
+   * leaves the pod in CrashLoopBackOff on reschedule. Raising this gives Redis
+   * room to shut down cleanly during node drains/upgrades.
+   *
+   * Defaults to the chart default (30s) when left unset.
+   */
+  terminationGracePeriodSeconds?: Input<number>;
 
   modules?: Input<string[]>;
   configuration?: Input<Record<string, string> | string>;
@@ -186,4 +201,27 @@ export const configurePriorityClass = (
     }
     return priorityClass ? priorityClass.name : priorityClassName;
   });
+};
+
+/**
+ * Builds a resource transform that sets `terminationGracePeriodSeconds` on every
+ * StatefulSet rendered by a Helm chart. Use this for charts (e.g. bitnami
+ * `redis-cluster`) that do not expose the grace period as a value, so it cannot
+ * be configured through `values` alone.
+ */
+export const configureTerminationGracePeriod = (
+  terminationGracePeriodSeconds: Input<number>,
+): ResourceTransform => {
+  return (args) => {
+    if (args.type !== 'kubernetes:apps/v1:StatefulSet') {
+      return undefined;
+    }
+    const props = args.props;
+    props.spec ??= {};
+    props.spec.template ??= {};
+    props.spec.template.spec ??= {};
+    props.spec.template.spec.terminationGracePeriodSeconds =
+      terminationGracePeriodSeconds;
+    return { props, opts: args.opts };
+  };
 };

--- a/src/resources/redis/kubernetesRedisCluster.ts
+++ b/src/resources/redis/kubernetesRedisCluster.ts
@@ -10,6 +10,7 @@ import {
   configurePriorityClass,
   configureResources,
   configureSidecarResources,
+  configureTerminationGracePeriod,
 } from './common';
 
 export type K8sRedisClusterArgs = Omit<CommonK8sRedisArgs, 'authKey'> & {
@@ -26,6 +27,21 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
     resourceOptions?: pulumi.CustomResourceOptions,
   ) {
     super(`${urnPrefix}:KubernetesRedisCluster`, name, args, resourceOptions);
+
+    // The bitnami redis-cluster chart does not expose terminationGracePeriodSeconds
+    // as a value, so patch it onto the rendered StatefulSet via a transform.
+    const chartOptions: pulumi.CustomResourceOptions =
+      args.terminationGracePeriodSeconds !== undefined
+        ? {
+            ...resourceOptions,
+            transforms: [
+              ...(resourceOptions?.transforms ?? []),
+              configureTerminationGracePeriod(
+                args.terminationGracePeriodSeconds,
+              ),
+            ],
+          }
+        : (resourceOptions ?? {});
 
     this.chart = new helm.v4.Chart(
       name,
@@ -87,7 +103,7 @@ export class KubernetesRedisCluster extends pulumi.ComponentResource {
           }),
         },
       },
-      resourceOptions,
+      chartOptions,
     );
   }
 }

--- a/src/resources/redis/kubernetesSentinel.ts
+++ b/src/resources/redis/kubernetesSentinel.ts
@@ -146,6 +146,7 @@ export class KubernetesSentinel extends ComponentResource {
             startupProbeArg,
             livenessProbeArg,
             readinessProbeArg,
+            args.terminationGracePeriodSeconds,
           ]).apply(
             ([
               spot,
@@ -153,6 +154,7 @@ export class KubernetesSentinel extends ComponentResource {
               startupProbe,
               livenessProbe,
               readinessProbe,
+              terminationGracePeriodSeconds,
             ]) => {
               const { tolerations, affinity } = getSpotSettings(
                 spot,
@@ -166,6 +168,9 @@ export class KubernetesSentinel extends ComponentResource {
                 ...(startupProbe && { startupProbe }),
                 ...(livenessProbe && { livenessProbe }),
                 ...(readinessProbe && { readinessProbe }),
+                ...(terminationGracePeriodSeconds != null && {
+                  terminationGracePeriodSeconds,
+                }),
                 topologySpreadConstraints: [
                   {
                     maxSkew: 1,


### PR DESCRIPTION
## Why

The bitnami Redis pods (`redis-cluster` and `redis` sentinel charts) run with the default **30s** `terminationGracePeriodSeconds`. On a node drain/upgrade, a Redis instance with AOF enabled and a multi-hundred-MB/GB dataset may not finish its SIGTERM shutdown (final RDB save + AOF flush) within 30s, so the kubelet sends `SIGKILL` mid-write. That truncates `appendonly.aof.<n>.incr.aof`, and Redis then refuses to start (`Bad file format reading the append only file ...`) → **CrashLoopBackOff** on reschedule.

We hit exactly this in the `feed` namespace after a GKE node-pool upgrade: 5 Redis pods (engagements/impressions cluster replicas + a sentinel history replica) landed in CrashLoopBackOff with truncated incr AOF files.

## What

Add an optional `terminationGracePeriodSeconds` to `CommonK8sRedisArgs` and wire it into both components:

- **`KubernetesSentinel`** — set via the chart's `replica.terminationGracePeriodSeconds` value.
- **`KubernetesRedisCluster`** — the bitnami `redis-cluster` chart (11.0.6) does **not** expose this as a value (only `redis.lifecycleHooks`), so it's applied with a Pulumi resource transform that patches `spec.template.spec.terminationGracePeriodSeconds` on the rendered StatefulSet. Added a reusable `configureTerminationGracePeriod()` helper for this.

## Compatibility

Fully backward compatible — when the arg is left unset, no value/transform is applied and the chart default (30s) is preserved.

## Testing

- `pnpm run build` ✅
- `pnpm run lint` ✅

Consumer side (daily-feed) sets `terminationGracePeriodSeconds: 120` on these Redis instances in a follow-up PR.