### PR TITLE
fix(redis): apply terminationGracePeriodSeconds in sentinel mode

### DIFF
--- a/src/resources/redis/kubernetesSentinel.ts
+++ b/src/resources/redis/kubernetesSentinel.ts
@@ -130,6 +130,14 @@ export class KubernetesSentinel extends ComponentResource {
               tag: image?.tag ?? '7.2.5-debian-12-r5',
             })),
             resources: configureSidecarResources(args.sentinel?.resources),
+            // In sentinel mode the deployed StatefulSet is rendered from the
+            // chart's sentinel template, so this is the value that sets the pod
+            // grace period. The chart also derives its graceful failover /
+            // CLIENT PAUSE timing from it, so setting the value (rather than
+            // patching the pod) keeps shutdown behaviour consistent.
+            ...(args.terminationGracePeriodSeconds !== undefined && {
+              terminationGracePeriodSeconds: args.terminationGracePeriodSeconds,
+            }),
           },
           image: all([args.image]).apply(([image]) => ({
             repository: image?.repository ?? 'daily-ops/bitnami-redis',
@@ -146,7 +154,6 @@ export class KubernetesSentinel extends ComponentResource {
             startupProbeArg,
             livenessProbeArg,
             readinessProbeArg,
-            args.terminationGracePeriodSeconds,
           ]).apply(
             ([
               spot,
@@ -154,7 +161,6 @@ export class KubernetesSentinel extends ComponentResource {
               startupProbe,
               livenessProbe,
               readinessProbe,
-              terminationGracePeriodSeconds,
             ]) => {
               const { tolerations, affinity } = getSpotSettings(
                 spot,
@@ -168,9 +174,6 @@ export class KubernetesSentinel extends ComponentResource {
                 ...(startupProbe && { startupProbe }),
                 ...(livenessProbe && { livenessProbe }),
                 ...(readinessProbe && { readinessProbe }),
-                ...(terminationGracePeriodSeconds != null && {
-                  terminationGracePeriodSeconds,
-                }),
                 topologySpreadConstraints: [
                   {
                     maxSkew: 1,


### PR DESCRIPTION
## Problem

Follow-up to #638. After deploying, the `redis-cluster` StatefulSets correctly got `terminationGracePeriodSeconds: 120`, but **both sentinel** StatefulSets (`redis-sauron-embeddings-node`, `redis-sauron-history-node`) were still at the **30s** default.

Root cause: the bitnami `redis` chart renders three different StatefulSet templates, each reading a different value:
- `replicas/application.yaml` → `replica.terminationGracePeriodSeconds`
- `sentinel/statefulset.yaml` → `sentinel.terminationGracePeriodSeconds`
- `master/application.yaml` → `master.terminationGracePeriodSeconds`

In sentinel mode the deployed `-node` StatefulSet comes from `sentinel/statefulset.yaml`, so it reads `sentinel.terminationGracePeriodSeconds`. #638 set `replica.terminationGracePeriodSeconds`, which that template ignores.

## Fix

Set `sentinel.terminationGracePeriodSeconds` directly. `KubernetesSentinel` always runs `sentinel.enabled: true`, so the deployed StatefulSet is unambiguously the sentinel one — no need to guess the value key or patch the pod.

Setting the chart value (rather than patching the rendered pod via a transform) is also the more correct choice here: the chart derives its graceful-shutdown timing from this value (`scripts-configmap.yaml` computes the sentinel failover wait and `CLIENT PAUSE` as `sub .Values.sentinel.terminationGracePeriodSeconds 10`). A transform would bump the pod grace period to 120s but leave that logic computing against 30s — a mismatch. The value keeps both aligned.

(The `redis-cluster` component still uses the `configureTerminationGracePeriod` transform from #638 because that chart does **not** expose a grace-period value — the asymmetry is inherent to the two charts.)

## Compatibility

Unchanged when the arg is unset (value omitted → chart default 30s).

## Testing

- `pnpm run build` ✅ / `pnpm run lint` ✅
- `helm template` with `sentinel.terminationGracePeriodSeconds=120` renders the `-node` StatefulSet with `terminationGracePeriodSeconds: 120`. ✅